### PR TITLE
Fix text sharing

### DIFF
--- a/android/src/main/java/com/rnlib/wechat/RNWechatModule.java
+++ b/android/src/main/java/com/rnlib/wechat/RNWechatModule.java
@@ -179,7 +179,7 @@ public class RNWechatModule extends ReactContextBaseJavaModule {
 
         WXTextObject textObject = new WXTextObject(text);
 
-        WXMediaMessage mediaMessage = WXMediaMessageHelper.getInstance(null, null, null, textObject);
+        WXMediaMessage mediaMessage = WXMediaMessageHelper.getInstance(null, text, null, textObject);
 
         SendMessageToWX.Req req = SendMessageToWXHelper.getInstance(mediaMessage, sceneType);
 


### PR DESCRIPTION
Problem:
Could not share text message to WeChat. After selecting recipient(s) in WeChat, the send dialog does not appear.

Solution:
According to 
[here](https://open.wechat.com/cgi-bin/newreadtemplate?t=overseas_open/docs/mobile/share/android), the description field should be set.
